### PR TITLE
Adds Northstar + sends Gambit replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,8 @@ DS_GAMBIT_CONVERSATIONS_API_BASEURI=https://gambit-conversations.dosomething.org
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=totallysecret
 
+DS_NORTHSTAR_API_BASEURI=https://northstar-thor.dosomething.org/v1
+DS_NORTHSTAR_API_KEY=00N00
+
 SLACK_API_TOKEN=xoxb-secret-bot-user-token
 SLACK_VERFICIATION_TOKEN=more.secrets

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -89,7 +89,7 @@ rtm.on(RTM_EVENTS.MESSAGE, (message) => {
   if (message.channel[0] !== 'D') return null;
 
   // Don't reply to our sent messages.
-  if (message.reply_to || message.bot_id) {
+  if (message.reply_to || message.bot_id || message.subtype === 'bot_message') {
     return null;
   }
 
@@ -127,7 +127,6 @@ rtm.on(RTM_EVENTS.MESSAGE, (message) => {
       return gambitConversations.postSlackMessage(payload);
     })
     .then((gambitRes) => {
-      logger.debug('gambit response', { data: gambitRes.body.data });
       const reply = gambitRes.body.data.messages.outbound[0];
       if (!reply.text) {
         return true;

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -26,6 +26,10 @@ rtm.on(Slack.CLIENT_EVENTS.RTM.AUTHENTICATED, (response) => {
 });
 
 function fetchNorthstarUserForSlackUserId(slackUserId) {
+  if (!slackUserId) {
+    return Promise.resolve();
+  }
+
   return cache.get(slackUserId)
     .then((user) => {
       if (user) {
@@ -69,9 +73,10 @@ function postCampaignIndexMessage(channel, environmentName) {
 
 /**
  * @param {string} channelId
- * @param {string} userId - Slack ID
+ * @param {string} slackUserId
+ * @param {string} campaignId
  */
-module.exports.postSignupMenuMessage = function (channelId, slackUserId, campaignId) {
+module.exports.postSignupMessage = function (channelId, slackUserId, campaignId) {
   const payload = {
     campaignId,
     platform,

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -71,11 +71,11 @@ module.exports.postSignupMenuMessage = function (channelId, slackUserId, campaig
   return fetchNorthstarUserForSlackUserId(slackUserId)
     .then((user) => {
       payload.northstarId = user.id;
-      return gambitConversations.postOutboundMessage(payload);
+      return gambitConversations.postSignupMessage(payload);
     })
     .then((gambitRes) => {
       const data = gambitRes.body.data;
-      logger.debug('gambitConversations.postOutboundMessage', { data });
+      logger.debug('gambitConversations.postSignupMessage', { data });
       return rtm.sendMessage(data.messages[0].text, channelId);
     })
     .catch(err => rtm.sendMessage(err.message, channelId));

--- a/app/routes/slack.js
+++ b/app/routes/slack.js
@@ -26,7 +26,7 @@ router.post('/', (req, res) => {
   const action = payload.actions[0];
 
   if (action.value === 'external-signup') {
-    return controller.postExternalSignupMenuMessage(channelId, userId, campaignId);
+    return controller.postSignupMenuMessage(channelId, userId, campaignId);
   }
 
   logger.info('Unknown action', { action, campaignId, userId, channelId });

--- a/app/routes/slack.js
+++ b/app/routes/slack.js
@@ -26,7 +26,7 @@ router.post('/', (req, res) => {
   const action = payload.actions[0];
 
   if (action.value === 'external-signup') {
-    return controller.postSignupMenuMessage(channelId, userId, campaignId);
+    return controller.postSignupMessage(channelId, userId, campaignId);
   }
 
   logger.info('Unknown action', { action, campaignId, userId, channelId });

--- a/config/lib/northstar.js
+++ b/config/lib/northstar.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  clientOptions: {
+    apiKey: process.env.DS_NORTHSTAR_API_KEY,
+    baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
+  },
+};

--- a/lib/gambit/conversations.js
+++ b/lib/gambit/conversations.js
@@ -41,3 +41,13 @@ module.exports.postSignupMessage = function (data) {
 
   return post('messages?origin=signup', data);
 };
+
+/**
+ * @param {object} data
+ * @return {Promise}
+ */
+module.exports.postBroadcastMessage = function (data) {
+  logger.debug('conversations.postBroadcastMessage', data);
+
+  return post('messages?origin=broadcast', data);
+};

--- a/lib/gambit/conversations.js
+++ b/lib/gambit/conversations.js
@@ -27,17 +27,17 @@ function post(endpoint, data) {
  * @return {Promise}
  */
 module.exports.postSlackMessage = function (data) {
-  logger.debug('chatbot.postInboundMessage', data);
+  logger.debug('conversations.postSlackMessage', data);
 
-  return post('messages?origin=slack', data);
+  return post('messages?origin=gambit-slack', data);
 };
 
 /**
  * @param {object} data
  * @return {Promise}
  */
-module.exports.postOutboundMessage = function (data) {
-  logger.debug('chatbot.postOutboundMessage', data);
+module.exports.postSignupMessage = function (data) {
+  logger.debug('conversations.postSignupMessage', data);
 
   return post('messages?origin=signup', data);
 };

--- a/lib/gambit/conversations.js
+++ b/lib/gambit/conversations.js
@@ -26,7 +26,7 @@ function post(endpoint, data) {
  * @param {object} data
  * @return {Promise}
  */
-module.exports.postInboundMessage = function (data) {
+module.exports.postSlackMessage = function (data) {
   logger.debug('chatbot.postInboundMessage', data);
 
   return post('messages?origin=slack', data);

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const Northstar = require('@dosomething/northstar-js');
+const logger = require('heroku-logger');
+const config = require('../config/lib/northstar');
+
+/**
+ * Setup.
+ */
+let client;
+
+/**
+ * @return {Object}
+ */
+module.exports.createNewClient = function createNewClient() {
+  const loggerMsg = 'northstar.createNewClient';
+
+  try {
+    client = new Northstar(config.clientOptions);
+    logger.info(`${loggerMsg} success`);
+  } catch (err) {
+    logger.error(`${loggerMsg} error`, err);
+    throw new Error(err.message);
+  }
+  return client;
+};
+
+/**
+ * @return {Object}
+ */
+module.exports.getClient = function getClient() {
+  if (!client) {
+    return exports.createNewClient();
+  }
+  return client;
+};
+
+/**
+ * @param {string} email
+ * @return {Promise}
+ */
+module.exports.fetchUserByEmail = function (email) {
+  logger.debug('fetchUserByEmail', { email });
+
+  return exports.getClient().Users.get('email', email);
+};
+

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "DoSomething.org",
   "license": "MIT",
   "dependencies": {
+    "@dosomething/northstar-js": "^1.0.0",
     "@slack/client": "^3.10.0",
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@slack/client": "^3.10.0",
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
+    "cacheman": "^2.2.1",
     "express": "^4.15.3",
     "heroku-logger": "^0.1.1",
     "superagent": "^3.5.0"


### PR DESCRIPTION
Corresponds to breaking Slack integration changes in https://github.com/DoSomething/gambit-conversations/pull/288:

* Adds Northstar integration to pass a `northstarId` to Conversations `POST /v2/messages?origin=gambit-slack`
* Posts the reply of a Gambit Conversations response to the channel it was sent from
* Restores Slack Signup Menu buttons for `thor` / `staging` keywords
* Starts on a `broadcast` command that replies with a hardcoded Broadcast ID to mock receiving a broadcast message