### PR TITLE
Broadcast command

### DIFF
--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -138,22 +138,19 @@ rtm.on(Slack.RTM_EVENTS.MESSAGE, (message) => {
   if (command === 'thor' || command === 'staging') {
     return postCampaignIndexMessage(channel, 'thor');
   }
-  // Hardcoding Broadcast command as a single Broadcast ID for now.
-  // TODO: Accept a 2nd ID parameter, e.g. "broadcast 5mPrrJjImQAGYi4goYWk2S"
   if (command === 'broadcast') {
-    return module.exports.postBroadcastMessage(channel, slackUserId, '5mPrrJjImQAGYi4goYWk2S');
-  }
-
-  let mediaUrl = null;
-  // Hack to upload images (when an image is shared over DM, it's private in Slack).
-  if (command === 'photo') {
-    mediaUrl = 'http://cdn1us.denofgeek.com/sites/denofgeekus/files/dirt-dave-and-gill.jpg';
+    const broadcastId = message.broadcastId;
+    if (!broadcastId) {
+      const errorMsg = 'You need to pass a Broadcast Id. Example:\n\n> broadcast 5mPrrJjImQAGYi4goYWk2S`';
+      return rtm.sendMessage(errorMsg, channel);
+    }
+    return module.exports.postBroadcastMessage(channel, slackUserId, broadcastId);
   }
 
   const payload = {
     messageId: message.ts,
     text: message.text,
-    mediaUrl,
+    mediaUrl: message.mediaUrl,
   };
 
   return fetchNorthstarUserForSlackUserId(slackUserId)

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -126,23 +126,18 @@ rtm.on(Slack.RTM_EVENTS.MESSAGE, (message) => {
     return null;
   }
 
-  logger.debug('slack message received', message);
+  helpers.message.parseMessage(message);
+
   const channel = message.channel;
-  let command;
-  if (message.text) {
-    command = message.text.toLowerCase().trim();
-  }
+  const command = message.command;
+  const slackUserId = message.user;
 
   if (command === 'keywords') {
     return postCampaignIndexMessage(channel, 'production');
   }
-
   if (command === 'thor' || command === 'staging') {
     return postCampaignIndexMessage(channel, 'thor');
   }
-
-  const slackUserId = message.user;
-
   // Hardcoding Broadcast command as a single Broadcast ID for now.
   // TODO: Accept a 2nd ID parameter, e.g. "broadcast 5mPrrJjImQAGYi4goYWk2S"
   if (command === 'broadcast') {
@@ -152,7 +147,6 @@ rtm.on(Slack.RTM_EVENTS.MESSAGE, (message) => {
   let mediaUrl = null;
   // Hack to upload images (when an image is shared over DM, it's private in Slack).
   if (command === 'photo') {
-    // TODO: Allow pasting image URL.
     mediaUrl = 'http://cdn1us.denofgeek.com/sites/denofgeekus/files/dirt-dave-and-gill.jpg';
   }
 

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -6,6 +6,7 @@ const logger = require('heroku-logger');
 
 const gambitCampaigns = require('../../lib/gambit/campaigns');
 const gambitConversations = require('../../lib/gambit/conversations');
+const helpers = require('../../lib/helpers');
 const northstar = require('../../lib/northstar');
 const slack = require('../../lib/slack');
 
@@ -20,9 +21,7 @@ const platform = 'gambit-slack';
 rtm.start();
 
 rtm.on(Slack.CLIENT_EVENTS.RTM.AUTHENTICATED, (response) => {
-  const bot = response.self.name;
-  const team = response.team.name;
-  logger.info('Slack authenticated.', { bot, team });
+  logger.info('Slack authenticated.', { bot: response.self.name });
 });
 
 function fetchNorthstarUserForSlackUserId(slackUserId) {
@@ -123,11 +122,7 @@ module.exports.postBroadcastMessage = function (channelId, slackUserId, broadcas
  * Handle message events.
  */
 rtm.on(Slack.RTM_EVENTS.MESSAGE, (message) => {
-  // Only respond to private messages.
-  if (message.channel[0] !== 'D') return null;
-
-  // Don't reply to our sent messages.
-  if (message.reply_to || message.bot_id || message.subtype === 'bot_message') {
+  if (!helpers.message.isDirectMessageFromUser(message)) {
     return null;
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const gambitCampaigns = require('./gambit/campaigns');
+const helpers = require('./helpers/index');
+
+// register helpers
+Object.keys(helpers).forEach((helperName) => {
+  module.exports[helperName] = helpers[helperName];
+});
 
 /**
  * Returns given campaign's title appended with its campaign id.

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const message = require('./message');
+
+module.exports = {
+  message,
+};

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function isDirectMessageFromUser(message) {
+  // Is this a direct message?
+  if (message.channel[0] !== 'D') return false;
+
+  // Ignore threaded messages.
+  if (message.reply_to) return false;
+
+  // Is this from a bot?
+  if (message.bot_id || message.subtype === 'bot_message') {
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = {
+  isDirectMessageFromUser,
+};

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -2,6 +2,8 @@
 
 const logger = require('heroku-logger');
 
+const mediaUrl = 'http://cdn1us.denofgeek.com/sites/denofgeekus/files/dirt-dave-and-gill.jpg';
+
 function isDirectMessageFromUser(message) {
   // Is this a direct message?
   if (message.channel[0] !== 'D') return false;
@@ -21,7 +23,17 @@ function isDirectMessageFromUser(message) {
 
 function parseMessage(message) {
   logger.debug('slack message received', message);
-  message.command = message.text.toLowerCase().trim(); // eslint-disable-line no-param-reassign
+  /* eslint-disable no-param-reassign */
+  message.command = message.text.toLowerCase().trim();
+  if (message.command === 'photo') {
+    message.mediaUrl = mediaUrl;
+  }
+  const params = message.text.split(' ');
+  if (params[0].toLowerCase() === 'broadcast') {
+    message.command = 'broadcast';
+    message.broadcastId = params[1];
+  }
+  /* eslint-enable no-param-reassign */
 }
 
 module.exports = {

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('heroku-logger');
+
 function isDirectMessageFromUser(message) {
   // Is this a direct message?
   if (message.channel[0] !== 'D') return false;
@@ -12,9 +14,17 @@ function isDirectMessageFromUser(message) {
     return false;
   }
 
+  if (!message.text) return false;
+
   return true;
+}
+
+function parseMessage(message) {
+  logger.debug('slack message received', message);
+  message.command = message.text.toLowerCase().trim(); // eslint-disable-line no-param-reassign
 }
 
 module.exports = {
   isDirectMessageFromUser,
+  parseMessage,
 };


### PR DESCRIPTION
Adds a `broadcast :broadcastId` command to send your Slack user a Gambit Broadcast.

Starts on a `lib/helpers` directory and moves Slack message parsing into a `helpers.message`.

TODO: Add config for hardcoded image, prefixes, etc.