### PR TITLE
Broadcast attachments [pr]

### DIFF
--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -113,7 +113,16 @@ module.exports.postBroadcastMessage = function (channelId, slackUserId, broadcas
     .then((gambitRes) => {
       const data = gambitRes.body.data;
       logger.debug('gambitConversations.postBroadcastMessage', { data });
-      return rtm.sendMessage(data.messages[0].text, channelId);
+      const message = data.messages[0];
+      const attachments = message.attachments.map((attachment) => {
+        const url = attachment.url;
+        // Note: Assuming we're only sending images  in Broadcasts.
+        return {
+          image_url: url,
+          fallback: url,
+        };
+      });
+      return web.chat.postMessage(channelId, message.text, { attachments });
     })
     .catch(err => rtm.sendMessage(err.message, channelId));
 };


### PR DESCRIPTION
Slack support for https://github.com/DoSomething/gambit-conversations/pull/301. Upon test deploy, you can test by messaging our `@gambit-staging` bot:
> broadcast 72mon4jUeQOaokEIkQMaoa


### Screenshot

<img width="618" alt="screen shot 2018-03-13 at 9 59 26 am" src="https://user-images.githubusercontent.com/1236811/37357289-4767d28c-26a5-11e8-9e7b-d06dc8ee7c34.png">
