### PR TITLE
Fixes keywords list + sends API error messages

### DIFF
--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -43,6 +43,15 @@ function fetchNorthstarUserForSlackUserId(slackUserId) {
     });
 }
 
+function postErrorMessage(channelId, error) {
+  let errorMessageText = error.message;
+  if (error.response && error.response.body) {
+    errorMessageText = error.response.body.message;
+  }
+  logger.error('postErrorMessage', { errorMessageText });
+  rtm.sendMessage(errorMessageText, channelId);
+}
+
 /**
  * Posts Campaign List Message to given Slack channel for given environmentName.
  * @param {object} channel
@@ -124,7 +133,7 @@ module.exports.postBroadcastMessage = function (channelId, slackUserId, broadcas
       });
       return web.chat.postMessage(channelId, message.text, { attachments });
     })
-    .catch(err => rtm.sendMessage(err.message, channelId));
+    .catch(error => postErrorMessage(channelId, error));
 };
 
 /**

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -56,8 +56,8 @@ function postErrorMessage(channel, error) {
 
 /**
  * Posts Campaign List Message to given Slack channel for given environmentName.
- * @param {object} channel
- * @param {string} environmentName
+ * @param {String} channel
+ * @param {String} environmentName
  * @return {Promise}
  */
 function postCampaignIndexMessage(channel, environmentName) {
@@ -77,7 +77,7 @@ function postCampaignIndexMessage(channel, environmentName) {
 }
 
 /**
- * @param {string} channelId
+ * @param {string} channel
  * @param {string} slackUserId
  * @param {string} campaignId
  */

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -43,13 +43,15 @@ function fetchNorthstarUserForSlackUserId(slackUserId) {
     });
 }
 
+/**
+ * Sends message to channelId where an error that has occurred.
+ * @param {String} channelId
+ * @param {Error} error
+ * @return {Promise}
+ */
 function postErrorMessage(channelId, error) {
-  let errorMessageText = error.message;
-  if (error.response && error.response.body) {
-    errorMessageText = error.response.body.message;
-  }
-  logger.error('postErrorMessage', { errorMessageText });
-  rtm.sendMessage(errorMessageText, channelId);
+  const message = slack.getMessageFromError(error);
+  return web.chat.postMessage(channelId, message.text, { attachments: message.attachments });
 }
 
 /**

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -65,8 +65,9 @@ function postCampaignIndexMessage(channel, environmentName) {
 
   return gambitCampaigns.index(environmentName)
     .then((response) => {
-      const text = `Gambit ${environmentName.toUpperCase()} campaigns:`;
-      const attachments = response.body.data.map((campaign, index) => {
+      const activeCampaigns = response.body.data.filter(campaign => campaign.status === 'active');
+      const text = `Active campaigns on Gambit ${environmentName.toUpperCase()}:`;
+      const attachments = activeCampaigns.map((campaign, index) => {
         const attachment = slack.parseCampaignAsAttachment(environmentName, campaign, index);
         return attachment;
       });

--- a/app/controllers/slack.js
+++ b/app/controllers/slack.js
@@ -73,12 +73,7 @@ function postCampaignIndexMessage(channel, environmentName) {
 
       return web.chat.postMessage(channel, text, { attachments });
     })
-    .then(() => logger.debug('postCampaignIndexMessage', { channel, environmentName }))
-    .catch((err) => {
-      const message = err.message;
-      rtm.sendMessage(message, channel);
-      logger.error('postCampaignIndexMessage', err);
-    });
+    .catch(error => postErrorMessage(channel, error));
 }
 
 /**

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -72,15 +72,19 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
  * @return {Object}
  */
 module.exports.getMessageFromError = function (error) {
-  let errorMessage = error.message;
+  let messageText = 'a `gambit-slack` error';
+  if (error.status) {
+    messageText = `a network error with status ${error.status}`;
+  }
+  let attachmentText = error.message;
   if (error.response && error.response.body) {
-    errorMessage = error.response.body.message;
+    attachmentText = error.response.body.message;
   }
   return {
-    text: `Whoops, an error with status ${error.status} occurred:`,
+    text: `Whoops, ${messageText} occurred:`,
     attachments: [{
       color: 'red',
-      text: errorMessage,
+      text: attachmentText,
     }],
   };
 };

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -31,9 +31,12 @@ module.exports.parseCallbackId = function (payload) {
  */
 module.exports.parseCampaignAsAttachment = function (environmentName, campaign, index) {
   logger.debug(`parseCampaignAsAttachment campaignId=${campaign.id}`);
-  const templatesLink = gambitAdmin.getCampaignUrl(environmentName, campaign.id);
-  const messagesLink = `${templatesLink}?skip=0`;
-  const keywords = campaign.keywords.join(', ');
+  const gambitAdminLink = gambitAdmin.getCampaignUrl(environmentName, campaign.id);
+  // For now, a campaign can only have one topic per the broadcast.campaign field.
+  // TODO: Update this once we build out topic broadcasts.
+  const firstTopic = campaign.topics[0];
+  const keywords = firstTopic.triggers.map(trigger => trigger.toUpperCase()).join(', ');
+  const webLink = helpers.getPhoenixCampaignUri(environmentName, campaign);
   const attachment = {
     callback_id: getCallbackIdForCampaign(environmentName, campaign),
     color: helpers.getHexForIndex(index),
@@ -41,13 +44,18 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
     title_link: helpers.getPhoenixCampaignUri(environmentName, campaign),
     fields: [
       {
-        title: 'Phoenix ID',
+        title: 'Campaign ID',
         value: `${campaign.id} (${campaign.status})`,
         short: true,
       },
       {
-        title: 'Gambit Links',
-        value: `<${templatesLink}|Templates> | <${messagesLink}|Messages>`,
+        title: 'Post type',
+        value: firstTopic.postType,
+        short: true,
+      },
+      {
+        title: 'Links',
+        value: `<${webLink}|Phoenix> | <${gambitAdminLink}|Gambit>`,
         short: true,
       },
     ],
@@ -72,19 +80,16 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
  * @return {Object}
  */
 module.exports.getMessageFromError = function (error) {
-  let messageText = 'a `gambit-slack` error';
-  if (error.status) {
-    messageText = `a network error with status ${error.status}`;
-  }
-  let attachmentText = error.message;
+  const statusText = error.status ? ` with status *${error.status}*` : '';
+  let errorMessageText = error.message;
   if (error.response && error.response.body) {
-    attachmentText = error.response.body.message;
+    errorMessageText = error.response.body.message;
   }
   return {
-    text: `Whoops, ${messageText} occurred:`,
+    text: `Whoops, an error${statusText} occurred:`,
     attachments: [{
       color: 'red',
-      text: attachmentText,
+      text: errorMessageText,
     }],
   };
 };

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -45,7 +45,7 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
     fields: [
       {
         title: 'Campaign ID',
-        value: `${campaign.id} (${campaign.status})`,
+        value: campaign.id,
         short: true,
       },
       {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -66,3 +66,21 @@ module.exports.parseCampaignAsAttachment = function (environmentName, campaign, 
 
   return attachment;
 };
+
+/**
+ * @param {Error} error
+ * @return {Object}
+ */
+module.exports.getMessageFromError = function (error) {
+  let errorMessage = error.message;
+  if (error.response && error.response.body) {
+    errorMessage = error.response.body.message;
+  }
+  return {
+    text: `Whoops, an error with status ${error.status} occurred:`,
+    attachments: [{
+      color: 'red',
+      text: errorMessage,
+    }],
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,6 +1252,11 @@
         "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
       }
     },
+    "dotenv": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
+      "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1880,7 +1885,7 @@
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "integrity": "sha512-g21Br4ELmVaKCVSUSSTXecKG+MiLcHFoby5RPPUmfZdhQTontXUOPf0QK/TvreRjgItRiyO928zxR4TCrnuwmA=="
     },
     "eyes": {
       "version": "0.1.8",
@@ -2397,7 +2402,7 @@
     "jodid25519": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+      "integrity": "sha512-b2Zna/wGIyTzi0Gemg27JYUaRyTyBETw5GnqyVQMr71uojOYMrgkD2+Px3bG2ZFi7/zTUXJSDoGoBOhMixq7tg==",
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -2432,7 +2437,7 @@
     "json-schema": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
+      "integrity": "sha512-DFzwwaFNKI+cfMyHtcyGA6N9d8jOWEtLc9IrT7WbpZc1V8M5S/HMBjJ3aM2Fx40bcTL2xTuIX/bBr8Zj2soGyg=="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2574,7 +2579,7 @@
     "mime-db": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+      "integrity": "sha512-lsX3UhcJITPHDXGOXSglBSPoI2UbcsWMmgX1VTaeXJ11TjjxOSE/DHrCl23zJk75odJc8MVpdZzWxdWt1Csx5Q=="
     },
     "mime-types": {
       "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
@@ -3261,7 +3266,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "stringstream": {
       "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -3439,7 +3444,7 @@
     "tweetnacl": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+      "integrity": "sha512-iNWodk4oBsZ03Qfw/Yvv0KB90uYrJqvL4Je7Gy4C5t/GS3sCXPRmIT1lxmId4RzvUp0XG62bcxJ2CBu/3L5DSg==",
       "optional": true
     },
     "type-check": {
@@ -3514,7 +3519,7 @@
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "integrity": "sha512-i8GFYwImt5D5B8CPpi2jrDTy/faq4OEW+NkOTLSKcIdPfdYJvWv3VZddDKl0ByvBe6cJ2s5Mm2XDtv5c2pj/Eg==",
       "requires": {
         "extsprintf": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
     "cacheman": "^2.2.1",
+    "dotenv": "^6.0.0",
     "eslint": "^4.19.1",
     "express": "^4.15.3",
     "heroku-logger": "^0.1.1",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('dotenv').config();
+
 const express = require('express');
 const bodyParser = require('body-parser');
 


### PR DESCRIPTION
Gives this app some ❤️ per recent Gambit API changes, fixing the campaigns list by sourcing keywords from the `campaign.topics` property instead of deprecated `keywords` property. Makes a few adjustments:

   * Excludes any campaigns with a `closed` status to help keep this list readable. Keywords for closed campaigns can be found via Gambit Admin
    * Adds a `postType` attachment field
    * Renames attachment title as `Campaign ID` instead of `Phoenix ID`

Also adds a `postErrorMessage` function to send the message returned in an error from the Gambit API:

<img width="400" alt="screen shot 2018-07-16 at 2 31 17 pm" src="https://user-images.githubusercontent.com/1236811/42784755-06889f2c-8905-11e8-96dc-3405b96dfa6d.png">
<img width="400" alt="screen shot 2018-07-16 at 2 35 48 pm" src="https://user-images.githubusercontent.com/1236811/42784943-91ecbd6e-8905-11e8-82e5-66a7dc84b596.png">
