### PR TITLE
Query GET /contentfulEntries for list of campaigns with web signups

### DIFF
--- a/lib/slack.js
+++ b/lib/slack.js
@@ -48,6 +48,10 @@ function isValidToken(token) {
  * @return {Object}
  */
 function parseOutboundMessage(res) {
+  const hasMessages = res.body.data && res.body.data.messages;
+  if (!hasMessages) {
+    return { text: '(no content)' };
+  }
   const isReply = res.body.data.messages.outbound;
   const message = isReply ? res.body.data.messages.outbound[0] : res.body.data.messages[0];
   const attachments = message.attachments.map((attachment) => {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -141,10 +141,14 @@ function sendGambitResponse(channel, gambitRes) {
  * @return {Promise}
  */
 async function sendSignup(channel, slackUserId, campaignId) {
-  logger.debug('sendSignup', { channel, slackUserId, campaignId });
-  const userId = await getUserIdBySlackUserId(slackUserId);
-  const gambitRes = await gambit.postSignupMessage(userId, campaignId);
-  return sendGambitResponse(channel, gambitRes);
+  try {
+    logger.debug('sendSignup', { channel, slackUserId, campaignId });
+    const userId = await getUserIdBySlackUserId(slackUserId);
+    const gambitRes = await gambit.postSignupMessage(userId, campaignId);
+    return sendGambitResponse(channel, gambitRes);
+  } catch (error) {
+    return sendErrorMessage(channel, error);
+  }
 }
 
 /**

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -98,22 +98,26 @@ function sendErrorMessage(channel, error) {
  */
 async function sendWebSignupList(channel) {
   rtm.sendTyping(channel);
-  // Note: we'll eventually query the webSignup list by finding all contentfulEntries with type
-  // campaign and where a webSignup field exists.
-  const gambitRes = await gambit.get('campaigns');
 
-  const activeCampaigns = gambitRes.body.filter(campaign => campaign.status === 'active');
-  const attachments = activeCampaigns.map((campaign, index) => ({
-    callback_id: campaign.id,
-    color: helpers.getHexForIndex(index),
-    title: helpers.getCampaignTitleWithId(campaign),
-    actions: [{
-      name: 'action',
-      text: 'Send test',
-      type: 'button',
-      value: 'webSignup',
-    }],
-  }));
+  const gambitRes = await gambit.get('contentfulEntries', {
+    content_type: 'campaign',
+    'fields.webSignup[exists]': true,
+  });
+
+  const attachments = gambitRes.body.map((entry, index) => {
+    const campaignId = entry.raw.fields.campaignId;
+    return {
+      callback_id: campaignId,
+      color: helpers.getHexForIndex(index),
+      title: campaignId,
+      actions: [{
+        name: 'action',
+        text: 'Send test',
+        type: 'button',
+        value: 'webSignup',
+      }],
+    };
+  });
 
   return sendMessage(channel, 'Current campaigns', attachments);
 }


### PR DESCRIPTION
Changes the `web` command results to list all campaigns that have a `webSignup` template config set per https://github.com/DoSomething/gambit-conversations/pull/423