### PR TITLE
Fix media URL for photo posts

### DIFF
--- a/config/lib/helpers/message.js
+++ b/config/lib/helpers/message.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  media: {
+    url: process.env.MEDIA_URL || 'https://user-images.githubusercontent.com/1236811/104386167-6d222700-54e9-11eb-90f1-f7402020e821.JPG',
+  },
+};

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 
-const mediaUrl = 'https://user-images.githubusercontent.com/1236811/104386167-6d222700-54e9-11eb-90f1-f7402020e821.JPG';
+const config = require('../../config/lib/helpers/message');
 
 /**
  * @param {Object} message
@@ -30,8 +30,9 @@ function parseMessage(message) {
   /* eslint-disable no-param-reassign */
   message.command = message.text.toLowerCase().trim();
 
+  // TODO: Inspect message for attachments instead of hardcoding an image URL.
   if (message.command === 'photo') {
-    message.mediaUrl = mediaUrl;
+    message.mediaUrl = config.media.url;
   }
 
   const params = message.text.split(' ');

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -4,6 +4,10 @@ const logger = require('heroku-logger');
 
 const mediaUrl = 'https://user-images.githubusercontent.com/1236811/104386167-6d222700-54e9-11eb-90f1-f7402020e821.JPG';
 
+/**
+ * @param {Object} message
+ * @return {Boolean}
+ */
 function isDirectMessageFromUser(message) {
   // Is this a direct message?
   if (message.channel[0] !== 'D') return false;

--- a/lib/helpers/message.js
+++ b/lib/helpers/message.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 
-const mediaUrl = 'http://cdn1us.denofgeek.com/sites/denofgeekus/files/dirt-dave-and-gill.jpg';
+const mediaUrl = 'https://user-images.githubusercontent.com/1236811/104386167-6d222700-54e9-11eb-90f1-f7402020e821.JPG';
 
 function isDirectMessageFromUser(message) {
   // Is this a direct message?
@@ -25,18 +25,23 @@ function parseMessage(message) {
   logger.debug('slack message received', message);
   /* eslint-disable no-param-reassign */
   message.command = message.text.toLowerCase().trim();
+
   if (message.command === 'photo') {
     message.mediaUrl = mediaUrl;
   }
+
   const params = message.text.split(' ');
+
   if (params[0].toLowerCase() === 'broadcast') {
     message.command = 'broadcast';
     message.broadcastId = params[1];
   }
+
   if (params[0].toLowerCase() === 'signup') {
     message.command = 'signup';
     message.campaignId = params[1];
   }
+
   /* eslint-enable no-param-reassign */
 }
 


### PR DESCRIPTION
This PR updates the URL of the dummy image used for submitting a photo post, because the URL now returns a 404 instead of an image of Mulder and Scully. Also adds the ability to override via config variable.

Ideally we should inspect an inbound Slack message for attachments, but that's never been such a big priority as this app is only used internally for testing.
